### PR TITLE
Added parameter 'address' to specify which address the server should listen to

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The directory where you keep your template files.
 A map of generator helpers. Functions that will be available in your template file. Some helpers are available out of the box, see (helpers)[#helpers]
 ### `log (optional)`
 A boolean specifying whether to log each request in the terminal. Defaults to false.
+### `address (optional)`
+Which address the server should listen to, default to `localhost`
 ### `port (optional)`
 Which port the server should be run on, defaults to 1989.
 ### `open (optional)`

--- a/index.js
+++ b/index.js
@@ -86,15 +86,17 @@ module.exports = function(vars) {
 
 
     var portNo = vars.port ? vars.port : 1989;
+    var address = vars.address ? vars.address : 'localhost';
 
-    var server = app.listen(portNo, function() {
+    var server = app.listen(portNo, address, function() {
 
         var port = server.address().port;
+        var address = server.address().address;
 
-        console.log('\nExample app listening at http://localhost:%s', port);
+        console.log('\nExample app listening at http://%s:%s', address, port);
 
     });
     if (vars.open) {
-        open("http://localhost:" + portNo + routes[0]);
+        open("http://" + address + ":" + portNo + routes[0]);
     }
 };


### PR DESCRIPTION
The parameter `address` can be set to any ip or domain. I need this for my project where the api-generator would run in a docker machine and needed to be accessible from outside. For this I needed the `address` to be `0.0.0.0`.
